### PR TITLE
Throw an error when the mutex already exists

### DIFF
--- a/src/mutex.cc
+++ b/src/mutex.cc
@@ -58,6 +58,12 @@ NAN_METHOD(Mutex::New) {
 		if (mutex == NULL) {
 			return Nan::ThrowError(Nan::Error("Error creating mutex"));
 		}
+
+		DWORD dwError = GetLastError();
+		if (dwError == ERROR_ALREADY_EXISTS) {
+			CloseHandle(mutex);
+			return Nan::ThrowError(Nan::Error("Error mutex already exists"));
+		}
 		
 		Mutex *obj = new Mutex(name, mutex);
 		obj->Wrap(info.This());


### PR DESCRIPTION
`  let isAlreadyStarted = false;
    let mu;
    try {
        mu = new Mutex.Mutex(mutexKey);
    } catch (error) {
        isAlreadyStarted = true;
    }
`