### PR TITLE
Supports c++17

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,6 +8,20 @@
       ],
       "include_dirs" : [
         "<!(node -e \"require('nan')\")"
+      ],
+      "conditions": [
+        ['OS=="mac"', {
+          "xcode_settings": {
+            "CLANG_CXX_LANGUAGE_STANDARD": "c++17"
+          }
+        }],
+        ['OS=="win"', {
+          "msvs_settings": {
+            "VCCLCompilerTool": {
+              "AdditionalOptions": [ "-std:c++17", ],
+            },
+          },
+        }]
       ]
     }
   ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -9,20 +9,13 @@
       "include_dirs" : [
         "<!(node -e \"require('nan')\")"
       ],
-      "conditions": [
-        ['OS=="mac"', {
-          "xcode_settings": {
-            "CLANG_CXX_LANGUAGE_STANDARD": "c++17"
-          }
-        }],
-        ['OS=="win"', {
-          "msvs_settings": {
-            "VCCLCompilerTool": {
-              "AdditionalOptions": [ "-std:c++17", ],
-            },
-          },
-        }]
-      ]
+      "msvs_settings": {
+        "VCCLCompilerTool": {
+          "AdditionalOptions": [
+            "-std:c++17"
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
V8 headers now use `c++17` by default. This flag was added for supports `c++17`.