### PR TITLE
fix: add QSpectre flag

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,7 +8,20 @@
       ],
       "include_dirs" : [
         "<!(node -e \"require('nan')\")"
-      ]
+      ],
+      'msvs_settings': {
+        'VCCLCompilerTool': {
+          'AdditionalOptions': [
+            '/Qspectre',
+            '/guard:cf'
+          ]
+        },
+        'VCLinkerTool': {
+          'AdditionalOptions': [
+            '/guard:cf'
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Fixes an issue in S360 that identified this module as missing the /QSpectre flag.