### PR TITLE
fix: allow types to be used on other platforms

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -19,9 +19,8 @@
               'AdditionalOptions': [
                 '/guard:cf',
                 '/ZH:SHA_256',
-                '/W3',
                 '/w34244',
-                '/w34267'
+                '/we4267'
               ]
             },
             'VCLinkerTool': {

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,31 +2,36 @@
   "targets": [
     {
       "target_name": "CreateMutex",
-      "sources": [
-        "src/main.cc",
-        "src/mutex.cc"
-      ],
-      "include_dirs" : [
-        "<!(node -e \"require('nan')\")"
-      ],
-      'msvs_configuration_attributes': {
-        'SpectreMitigation': 'Spectre'
-      },
-      'msvs_settings': {
-        'VCCLCompilerTool': {
-          'AdditionalOptions': [
-            '/guard:cf',
-            '/ZH:SHA_256',
-            '/w34244',
-            '/we4267'
-          ]
-        },
-        'VCLinkerTool': {
-          'AdditionalOptions': [
-            '/guard:cf'
-          ]
-        }
-      }
+      "conditions": [
+        ['OS=="win"', {
+          "sources": [
+            "src/main.cc",
+            "src/mutex.cc"
+          ],
+          "include_dirs" : [
+            "<!(node -e \"require('nan')\")"
+          ],
+          'msvs_configuration_attributes': {
+            'SpectreMitigation': 'Spectre'
+          },
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'AdditionalOptions': [
+                '/guard:cf',
+                '/ZH:SHA_256',
+                '/W3',
+                '/w34244',
+                '/w34267'
+              ]
+            },
+            'VCLinkerTool': {
+              'AdditionalOptions': [
+                '/guard:cf'
+              ]
+            }
+          }
+        }]
+      ]
     }
   ]
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export class Mutex {
+	constructor(name: string);
+	isActive(): boolean;
+	release(): void;
+}
+export function isActive(name: string): boolean;

--- a/index.js
+++ b/index.js
@@ -1,1 +1,15 @@
-module.exports = require('bindings')('CreateMutex');
+const isWindows = process.platform === 'win32';
+if (isWindows) {
+    module.exports = require('bindings')('CreateMutex');
+} else {
+    function platformThrow(functionName) {
+        throw new Error(`The node-windows-mutex function ${functionName} has only been implemented on Windows.`);
+    }
+    class Mutex {
+        constructor(name) { platformThrow("Mutex#constructor"); }
+        isActive() { platformThrow("Mutex#isActive"); }
+        release() { platformThrow("Mutex#release"); }
+    }
+    function isActive(name) { platformThrow("isActive"); }
+    module.exports = { Mutex, isActive }
+}

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ if (isWindows) {
     }
     class Mutex {
         constructor(name) { platformThrow("Mutex#constructor"); }
-        isActive() { platformThrow("Mutex#isActive"); }
-        release() { platformThrow("Mutex#release"); }
+        isActive() { }
+        release() { }
     }
     function isActive(name) { platformThrow("isActive"); }
     module.exports = { Mutex, isActive }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.3",
   "description": "Expose the Windows CreateMutex API to Node.JS",
   "main": "index.js",
+  "types": "index.d.ts",
   "homepage": "https://github.com/microsoft/node-windows-mutex",
   "bugs": "https://github.com/microsoft/node-windows-mutex/issues",
   "repository": {
@@ -11,9 +12,6 @@
   },
   "author": "Microsoft",
   "license": "MIT",
-  "os": [
-    "win32"
-  ],
   "dependencies": {
     "bindings": "^1.2.1",
     "nan": "^2.17.0"

--- a/pipelines/main.yml
+++ b/pipelines/main.yml
@@ -13,6 +13,15 @@ stages:
       VSCODE_ARCH: ia32
     steps:
       - template: templates/windows.yml
+- stage: macOS
+  pool:
+    vmImage: macos-latest
+  jobs:
+  - job: darwin_x64
+    variables:
+      VSCODE_ARCH: x64
+    steps:
+      - template: templates/macos.yml
 
 trigger:
   branches:

--- a/pipelines/publish.yml
+++ b/pipelines/publish.yml
@@ -36,6 +36,14 @@ extends:
           - name: Windows
             nodeVersions:
               - 16.x
+            
+          - name: macOS
+            nodeVersions:
+              - 16.x
+
+          - name: linux
+            nodeVersions:
+              - 16.x
 
         testSteps:
           - script: yarn --frozen-lockfile

--- a/pipelines/templates/macos.yml
+++ b/pipelines/templates/macos.yml
@@ -1,0 +1,19 @@
+steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: '16.x'
+
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.x'
+    addToPath: true
+
+- script: |
+    npm_config_arch="$(VSCODE_ARCH)"
+    yarn install --frozen-lockfile
+  displayName: Install Dependencies
+
+- script: |
+    yarn test
+  displayName: Run Tests
+  condition: and(succeeded(), eq(variables['VSCODE_ARCH'], 'x64'))

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,9 @@
 /*global describe,it*/
 
-var assert = require('assert');
-var lib = require('../');
-var Mutex = lib.Mutex;
+const assert = require('assert');
+const lib = require('../');
+const Mutex = lib.Mutex;
+const isWindows = process.platform === 'win32';
 
 describe('Mutex', function () {
 	it('constructor should throw with bad arguments', function () {
@@ -11,25 +12,33 @@ describe('Mutex', function () {
 		});
 	});
 	
-	it('should release', function () {
-		var mutex = new Mutex("demo-mutex");
-		assert(mutex.release());
-	});
-	
-	it('should release twice successfully', function () {
-		var mutex = new Mutex("demo-mutex");
-		assert(mutex.release());
-		assert(!mutex.release());
-	});
-	
-	describe('isActive', function () {
-		it('should work', function () {
-			var mutex = new Mutex("demo-mutex");
-			assert(mutex.isActive());
-			mutex.release();
-			assert(!mutex.isActive());
+	if (isWindows) {
+		it('should release', function () {
+			const mutex = new Mutex("demo-mutex");
+			assert(mutex.release());
 		});
-	});
+		
+		it('should release twice successfully', function () {
+			const mutex = new Mutex("demo-mutex");
+			assert(mutex.release());
+			assert(!mutex.release());
+		});
+		
+		describe('isActive', function () {
+			it('should work', function () {
+				const mutex = new Mutex("demo-mutex");
+				assert(mutex.isActive());
+				mutex.release();
+				assert(!mutex.isActive());
+			});
+		});
+	} else {
+		it('should throw', function () {
+			assert.throws(function () {
+				new Mutex("demo-mutex");
+			});
+		});
+	}
 });
 
 describe('isActive', function () {
@@ -39,15 +48,23 @@ describe('isActive', function () {
 		});
 	});
 	
-	it('should work', function () {
-		assert(!lib.isActive("demo-mutex"));
-		
-		var mutex = new Mutex("demo-mutex");
-		assert(mutex.isActive());
-		assert(lib.isActive("demo-mutex"));
-		
-		mutex.release();
-		assert(!mutex.isActive());
-		assert(!lib.isActive("demo-mutex"));
-	});
+	if (isWindows) {
+		it('should work', function () {
+			assert(!lib.isActive("demo-mutex"));
+			
+			const mutex = new Mutex("demo-mutex");
+			assert(mutex.isActive());
+			assert(lib.isActive("demo-mutex"));
+			
+			mutex.release();
+			assert(!mutex.isActive());
+			assert(!lib.isActive("demo-mutex"));
+		});
+	} else {
+		it('should throw', function () {
+			assert.throws(function () {
+				lib.isActive("demo-mutex");
+			})
+		});
+	}
 });


### PR DESCRIPTION
This PR adds types to the module, and makes the module installable on all platforms for access to the types in a cross-platform-development context. However, attempting to call into any of the functions on a non-Windows platform will result in an exception being thrown.

This PR is a test run for windows-process-tree. Windows-process-tree is a much larger module and it'll take longer to convert it in a similar way.